### PR TITLE
Use newest version of temporary to fix error with node 0.11+

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "mustache": "~0.8.0",
-    "temporary": "0.0.7",
+    "temporary": "0.0.8",
     "minimist": "0.0.5",
     "moment": "^2.6.0"
   }


### PR DESCRIPTION
Fixes to work with newest node versions
