### PR TITLE
modify regexp in detector.js for file with BOM

### DIFF
--- a/lib/detector.js
+++ b/lib/detector.js
@@ -10,7 +10,8 @@ var app_info = JSON.parse(fs.readFileSync(__dirname+'/../resources/versions.json
 module.exports = function(code){
   
   var code = (typeof 'string' === code)? code : code.toString();
-  var re = /^\#target (.*?)(?:\s|\-)(\S*)(?:\s|$)/gi;
+  // run both with BOM and without BOM
+  var re = /^\uFEFF?\#target (.*?)(?:\s|\-)(\S*)(?:\s|$)/gi;
   if(code.match(re)){
     var m = re.exec(code);
     var _name = (m[1]).toLowerCase().replace(/['|"|;]/g,''),

--- a/test/fixtures/ind_cs5withbom.jsx
+++ b/test/fixtures/ind_cs5withbom.jsx
@@ -1,0 +1,2 @@
+﻿#target InDesign-7.0
+$.write("with BOM");

--- a/test/test.js
+++ b/test/test.js
@@ -124,4 +124,21 @@ describe('command line action',function(){
       done();
     });
   });
+
+  it('with callback +BOM',function(done){
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs5withbom.jsx');
+    fakestk.run(jsx,function(err,r){
+      r.should.eql("with BOM");
+      done();
+    });
+  });
+
+  it('without callback +BOM',function(done){
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs5withbom.jsx');
+    var exe = fakestk.run(jsx);
+    exe.on('data',function(d){
+      d.should.eql("with BOM");
+      done();
+    });
+  });
 });


### PR DESCRIPTION
The script file that starts with BOM (\uFEFF) won't match in `#target` line.
