### PR TITLE
allow linting by using //@target instead of #target

### DIFF
--- a/lib/detector.js
+++ b/lib/detector.js
@@ -8,10 +8,10 @@ var app_info = JSON.parse(fs.readFileSync(__dirname+'/../resources/versions.json
 // return adobe application's name and version from ExtendScript source.
 // argument `code` is String or Buffer. return Object or null.
 module.exports = function(code){
-  
+
   var code = (typeof 'string' === code)? code : code.toString();
   // run both with BOM and without BOM
-  var re = /^\uFEFF?\#target (.*?)(?:\s|\-)(\S*)(?:\s|$)/gi;
+  var re = /^\uFEFF?\/*[\#@]target (.*?)(?:\s|\-)(\S*)(?:\s|$)/gi;
   if(code.match(re)){
     var m = re.exec(code);
     var _name = (m[1]).toLowerCase().replace(/['|"|;]/g,''),

--- a/test/fixtures/ind_cs6.jsx
+++ b/test/fixtures/ind_cs6.jsx
@@ -1,0 +1,3 @@
+//@target InDesign-8.0
+
+$.writeln('ok');

--- a/test/fixtures/ind_cs6withbom.jsx
+++ b/test/fixtures/ind_cs6withbom.jsx
@@ -1,0 +1,2 @@
+﻿//@target InDesign-8.0
+$.write("with BOM");

--- a/test/test.js
+++ b/test/test.js
@@ -3,12 +3,20 @@ var fs = require('fs'),
 
 var detector = require(__dirname+'/../lib/detector');
 describe('detecotor test',function(){
-  
+
   it('Adobe InDesign CS5',function(done){
     var v = ['#target indesign-7.0','alert("ok");'].join("\n");
     detector(v).should.have.property('name','InDesign');
     detector(v).should.have.property('version','7.0');
     detector(v).should.have.property('cs_version','CS5');
+    done();
+  });
+
+  it('Adobe InDesign CS6',function(done){
+    var v = ['//@target indesign-8.0','alert("ok");'].join("\n");
+    detector(v).should.have.property('name','InDesign');
+    detector(v).should.have.property('version','8.0');
+    detector(v).should.have.property('cs_version','CS6');
     done();
   });
 
@@ -63,6 +71,23 @@ describe('executor test',function(){
     });
   });
 
+  it('runs indesign cs6 with callback',function(done){
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs6.jsx');
+    executor(jsx,function(e,r){
+      r.should.eql("ok\r\n");
+      done();
+    });
+  });
+
+  it('runs indesign cs6 without callback',function(done){
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs6.jsx');
+    var exe = executor(jsx);
+    exe.on('data',function(d){
+      d.should.eql("ok\r\n");
+      done();
+    });
+  });
+
   it('runs indesign cc with callback',function(done){
     var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cc.jsx');
     executor(jsx,function(e,r){
@@ -96,8 +121,8 @@ describe('executor test',function(){
     });
   });
 
-  it('runs indesign cs5 without callback and contains #include in jsx',function(done){
-    var cont = ["#target InDesign-7.0","#include \""+__dirname+"/fixtures/inc.jsx\"","inc();"].join("\n");
+  it('runs indesign cs6 without callback and contains #include in jsx',function(done){
+    var cont = ["#target InDesign-8.0","#include \""+__dirname+"/fixtures/inc.jsx\"","inc();"].join("\n");
     var exe = executor(cont);
     exe.on('data',function(d){
       d.should.eql("this is inc\r\n");
@@ -109,7 +134,7 @@ describe('executor test',function(){
 var fakestk = require(__dirname+'/../lib');
 describe('command line action',function(){
   it('with callback',function(done){
-    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs5.jsx');
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs6.jsx');
     fakestk.run(jsx,function(err,r){
       r.should.eql("ok\r\n");
       done();
@@ -117,7 +142,7 @@ describe('command line action',function(){
   });
 
   it('without callback',function(done){
-    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs5.jsx');
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs6.jsx');
     var exe = fakestk.run(jsx);
     exe.on('data',function(d){
       d.should.eql("ok\r\n");
@@ -126,7 +151,7 @@ describe('command line action',function(){
   });
 
   it('with callback +BOM',function(done){
-    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs5withbom.jsx');
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs6withbom.jsx');
     fakestk.run(jsx,function(err,r){
       r.should.eql("with BOM");
       done();
@@ -134,7 +159,7 @@ describe('command line action',function(){
   });
 
   it('without callback +BOM',function(done){
-    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs5withbom.jsx');
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs6withbom.jsx');
     var exe = fakestk.run(jsx);
     exe.on('data',function(d){
       d.should.eql("with BOM");


### PR DESCRIPTION
Just adding an option to use `//@target` (as well as `#target`) in the code.

Using `//@target` allows for linting tools to work properly over the code instead of stopping when it encounters `#target`.