### PR TITLE
We need to activate the app when running multiple tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakestk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "CUI Adobe ExtendScript runner. Accept script file or stdin. currently osx only",
   "main": "index.js",
   "bin": "cmd.js",

--- a/resources/tpl.scpt
+++ b/resources/tpl.scpt
@@ -1,4 +1,5 @@
 tell application "{{{app_name}}}"
+  activate
   with timeout of (1 * 60 * 60) seconds
     {{{run_script}}}
   end timeout


### PR DESCRIPTION
Otherwise, the test pauses until the app is activated (Eg brought to
foreground my clicking the target app icon in the dock)

Sorry to have missed this. I'm pretty sure this is the last PR for a while!

Bruno
