### PR TITLE
Support for targeting curently running version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-## Fakestk
+# Fakestk
 
 Fakestk (Fake ESTK) Adobe ExtendScript(JSX) simple command runner.
 
 * auto detection of CS application name
 
-    > version number needs to be specified in target  
-    > `#target indesign-7.0`  
-    > see [versions.json](./resources/versions.json)  
+> Version can be specified in target. `#target indesign-7.0` and `@target InDesign CC-2018` both work. When no version is specified (`#target indesign`), Fakestk will target the first running version it can find. Make sure your target is running! See [versions.json](./resources/versions.json)
 
 * accept stdin
 * from $.write and $.writeln output to stdout
 * currently OSX only
 
-### Usage
+## Usage
 
     $ npm install -g fakestk
 

--- a/lib/detector.js
+++ b/lib/detector.js
@@ -11,11 +11,13 @@ module.exports = function(code){
 
   var code = (typeof 'string' === code)? code : code.toString();
   // run both with BOM and without BOM
-  var re = /^\uFEFF?\/*[\#@]target (.*?)(?:\s|\-)(\S*)(?:\s|$)/gi;
+  var re = /(?=^|[\r\n])(\uFEFF?\/*[\#@]target )(['"a-z]*)(?:\s|\-)?(['"a-z0-9\.\-]*)(?=[;\n\r]|$)/im;
+
   if(code.match(re)){
     var m = re.exec(code);
-    var _name = (m[1]).toLowerCase().replace(/['|"|;]/g,''),
-        _version = m[2].replace(/['|"|;]/g,'');
+    var _name = (m[2]).toLowerCase().replace(/['|"|;]/,'');
+    var _version = (m[3]).replace(/['|"|;]/,'');
+    if(_version === '') _version = "Open";
 
     var app = app_info[_name];
     if(app!==undefined){
@@ -31,4 +33,3 @@ module.exports = function(code){
     return null
   }
 };
-

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -7,8 +7,6 @@ var detector = require('./detector'),
     tmp = require('temporary'),
     moment = require('moment');
 
-var scpt_tpl = fs.readFileSync(__dirname+'/../resources/tpl.scpt').toString();
-
 // head message
 function headMessage(){
   var now = moment().format('YYYY-MM-DD HH:mm:ss');
@@ -87,7 +85,7 @@ module.exports = function(code,target,args,done){
   var name = info.name,
       ver = info.version,
       cs_version = info.cs_version;
-  var cs_name, run_script;
+  var cs_name, run_script, scpt_tpl;
 
   if(code==='') return null;
 
@@ -95,11 +93,29 @@ module.exports = function(code,target,args,done){
   fs.writeFileSync(jsx_path,headMessage()+code);
 
   // tell application
-  if(name==='Illustrator'){
-    cs_name = "/Applications/Adobe Illustrator "+cs_version+"/Adobe Illustrator.app";
-  }else{
-    cs_name = ['Adobe',name,cs_version].join(' ');
-  }
+  if(ver==='Open'){
+    scpt_tpl = fs.readFileSync(__dirname+'/../resources/tpl_id.scpt').toString();
+    switch( name ) {
+      case 'Illustrator':
+        cs_name = 'com.adobe.illustrator';
+        break;
+      case 'Photoshop':
+        cs_name = 'com.adobe.Photoshop';
+        break;
+      case 'InDesign':
+        cs_name = 'com.adobe.indesign';
+        break;
+      default:
+        break;
+    };
+  } else {
+    scpt_tpl = fs.readFileSync(__dirname+'/../resources/tpl.scpt').toString();
+    if(name==='Illustrator'){
+      cs_name = "/Applications/Adobe Illustrator "+cs_version+"/Adobe Illustrator.app";
+    }else{
+      cs_name = ['Adobe',name,cs_version].join(' ');
+    };
+  };
 
   // temporary log file (overwrite $.write, $.writeln)
   var log_file = new tmp.File();
@@ -126,6 +142,7 @@ module.exports = function(code,target,args,done){
   }
 
   // templating
+
   var scpt_code = Mustache.render(scpt_tpl,{app_name: cs_name, run_script: run_script});
   var scpt = createAppleScript(scpt_code);
 

--- a/resources/tpl_id.scpt
+++ b/resources/tpl_id.scpt
@@ -1,4 +1,4 @@
-tell application "{{{app_name}}}"
+tell application id "{{{app_name}}}"
   activate
   with timeout of (1 * 60 * 60) seconds
     {{{run_script}}}

--- a/resources/versions.json
+++ b/resources/versions.json
@@ -2,6 +2,7 @@
   "indesign": {
     "name": "InDesign",
     "versions": {
+      "Open": "",
       "CS3": "CS3",
       "5.0": "CS3",
       "5": "CS3",
@@ -38,6 +39,7 @@
   "illustrator": {
     "name": "Illustrator",
     "versions": {
+      "Open": "",
       "CS3": "CS3",
       "13.0": "CS3",
       "13": "CS3",
@@ -86,6 +88,7 @@
   "photoshop": {
     "name": "Photoshop",
     "versions": {
+      "Open": "",
       "CS3": "CS3",
       "10.0": "CS3",
       "10": "CS3",

--- a/test/fixtures/ind_open.jsx
+++ b/test/fixtures/ind_open.jsx
@@ -1,0 +1,3 @@
+//@target InDesign
+
+$.writeln('ok');

--- a/test/fixtures/ind_openwithbom.jsx
+++ b/test/fixtures/ind_openwithbom.jsx
@@ -1,0 +1,2 @@
+//@target InDesign
+$.write("with BOM");

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,15 @@ var fs = require('fs'),
     should = require('should');
 
 var detector = require(__dirname+'/../lib/detector');
-describe('detecotor test',function(){
+describe('detector test',function(){
+
+  it('Adobe InDesign Running',function(done){
+    var v = ['#target indesign','alert("ok");'].join("\n");
+    detector(v).should.have.property('name','InDesign');
+    detector(v).should.have.property('version','Open');
+    detector(v).should.have.property('cs_version','');
+    done();
+  });
 
   it('Adobe InDesign CS5',function(done){
     var v = ['#target indesign-7.0','alert("ok");'].join("\n");
@@ -182,7 +190,7 @@ describe('executor test',function(){
     });
   });
   
-  it('runs indesign cc 2018 with indesign cs5 target override',function(done){
+  it('runs indesign cc 2018 on target override with callback',function(done){
     var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cs5.jsx');
     executor(jsx,"InDesign-13",function(e,r){
       r.should.eql("ok\r\n");
@@ -311,4 +319,22 @@ describe('command line action',function(){
       done();
     });
   });
+
+  it('runs open indesign application with callback +BOM',function(done){
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_cc2018withbom.jsx');
+    fakestk.run(jsx,function(err,r){
+      r.should.eql("with BOM");
+      done();
+    });
+  });
+
+  it('runs open indesign application without callback +BOM',function(done){
+    var jsx = fs.readFileSync(__dirname+'/fixtures/ind_openwithbom.jsx');
+    var exe = fakestk.run(jsx);
+    exe.on('data',function(d){
+      d.should.eql("with BOM");
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
So we can do:

    fakestk /path/to/script.jsx -t indesign

To run it in the InDesign version that is currently running.
Scripts with these targets will work as well when InDesign is active:

    #target indesign
